### PR TITLE
Follows the redirect responses in the backend

### DIFF
--- a/client.go
+++ b/client.go
@@ -46,7 +46,7 @@ func (t *Tor) Start(c *caddy.Controller) {
 // Stop stops the tor instance, context listener and the onion service
 func (t *Tor) Stop() error {
 	if err := t.instance.Close(); err != nil {
-		return fmt.Errorf("[txtdirect]: Couldn't close the tor instance. %s", err.Error())
+		return fmt.Errorf("[torproxy]: Couldn't close the tor instance. %s", err.Error())
 	}
 	t.onion.Close()
 	return nil

--- a/response.go
+++ b/response.go
@@ -6,6 +6,8 @@ import (
 	"io"
 	"net/http"
 	"sync"
+
+	"golang.org/x/net/proxy"
 )
 
 type TorResponse struct {
@@ -14,6 +16,9 @@ type TorResponse struct {
 	bodyReader bytes.Buffer
 	bodyWriter bytes.Buffer
 	status     int
+
+	request *http.Request
+	dialer  proxy.Dialer
 }
 
 var bufferPool = sync.Pool{New: createBuffer}

--- a/torproxy.go
+++ b/torproxy.go
@@ -45,10 +45,15 @@ func (c Config) Proxy(w http.ResponseWriter, r *http.Request) error {
 	}
 
 	// If the received response is a redirect, proxy the request to the response's Location header
-	if tmpResponse.status == http.StatusFound || tmpResponse.status == http.StatusMovedPermanently {
-		if err = tmpResponse.Redirect(); err != nil {
-			return fmt.Errorf("[torproxy]: Couldn't redirect the request to the response's \"Location\" header: %s", err)
+	// Do this until the final response isn't a redirect response
+	for {
+		if tmpResponse.status == http.StatusFound || tmpResponse.status == http.StatusMovedPermanently {
+			if err = tmpResponse.Redirect(); err != nil {
+				return fmt.Errorf("[torproxy]: Couldn't redirect the request to the response's \"Location\" header: %s", err)
+			}
+			continue
 		}
+		break
 	}
 
 	// Decompress the body based on "Content-Encoding" header and write to a writer buffer

--- a/torproxy.go
+++ b/torproxy.go
@@ -26,24 +26,39 @@ func (c Config) Proxy(w http.ResponseWriter, r *http.Request) error {
 		return fmt.Errorf("Couldn't connect to socks proxy: %s", err.Error())
 	}
 
+	// Setup the resverse proxy client for the request's endpoint
 	reverseProxy := cproxy.NewSingleHostReverseProxy(u, "", torProxyKeepalive, torProxyTimeout, torFallbackDelay)
 	reverseProxy.Transport = &http.Transport{
 		Dial: dialer.Dial,
 	}
 
-	tmpResponse := TorResponse{headers: make(http.Header)}
+	// Create a temporary response writer to save response's body and headers
+	tmpResponse := TorResponse{
+		headers: make(http.Header),
+		dialer:  dialer,
+		request: r,
+	}
+
+	// Proxy the request and write the response to the temporary response writer
 	if err := reverseProxy.ServeHTTP(&tmpResponse, r, nil); err != nil {
-		return fmt.Errorf("[txtdirect]: Coudln't proxy the request to the background onion service. %s", err.Error())
+		return fmt.Errorf("[torproxy]: Coudln't proxy the request to the background onion service. %s", err.Error())
+	}
+
+	// If the received response is a redirect, proxy the request to the response's Location header
+	if tmpResponse.status == http.StatusFound || tmpResponse.status == http.StatusMovedPermanently {
+		if err = tmpResponse.Redirect(); err != nil {
+			return fmt.Errorf("[torproxy]: Couldn't redirect the request to the response's \"Location\" header: %s", err)
+		}
 	}
 
 	// Decompress the body based on "Content-Encoding" header and write to a writer buffer
 	if err := tmpResponse.WriteBody(); err != nil {
-		return fmt.Errorf("[txtdirect]: Couldn't write the response body: %s", err.Error())
+		return fmt.Errorf("[torproxy]: Couldn't write the response body: %s", err.Error())
 	}
 
 	// Replace the URL hosts with the request's host
 	if err := tmpResponse.ReplaceBody(u.Scheme, u.Host, r.Host); err != nil {
-		return fmt.Errorf("[txtdirect]: Couldn't replace urls inside the response body: %s", err.Error())
+		return fmt.Errorf("[torproxy]: Couldn't replace urls inside the response body: %s", err.Error())
 	}
 
 	copyHeader(w.Header(), tmpResponse.Header())
@@ -53,8 +68,26 @@ func (c Config) Proxy(w http.ResponseWriter, r *http.Request) error {
 
 	// Write the final response from the temporary ResponseWriter to the main ResponseWriter
 	if _, err := w.Write(tmpResponse.Body()); err != nil {
-		return fmt.Errorf("[txtdirect]: Couldn't write the temporary response to main response body: %s", err.Error())
+		return fmt.Errorf("[torproxy]: Couldn't write the temporary response to main response body: %s", err.Error())
 	}
 
+	return nil
+}
+
+// Redirect redirects the request to the previous response's Location header.
+func (t *TorResponse) Redirect() error {
+	u, err := url.Parse(t.Header().Get("Location"))
+	if err != nil {
+		return fmt.Errorf("[torproxy]: Couldn't parse the URI from Redirect response: %s", err)
+	}
+
+	reverseProxy := cproxy.NewSingleHostReverseProxy(u, "", torProxyKeepalive, torProxyTimeout, torFallbackDelay)
+	reverseProxy.Transport = &http.Transport{
+		Dial: t.dialer.Dial,
+	}
+
+	if err := reverseProxy.ServeHTTP(t, t.request, nil); err != nil {
+		return fmt.Errorf("[torproxy]: Coudln't proxy the request to the background onion service. %s", err.Error())
+	}
 	return nil
 }


### PR DESCRIPTION
**What this PR does / why we need it**:
Follows the redirect responses in the backend without showing the user.

**Which issue this PR fixes**:
fixes #7 


**Special notes for your reviewer**:
The `for` loop used to follow all the redirect responses doesn't feel good to me cause I think it makes the code harder to read but couldn't think of another approach. Would love to hear other thoughts.
