### PR TITLE
[config]: Fix the config parser and add Host field

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -26,11 +26,11 @@ docker-run: image-build
 
 docker-test:
 	docker run --network=host -v $(shell pwd):/source -v $(GOPATH)/pkg/mod:/go/pkg/mod golang:1.13-alpine /bin/sh \
-	-c "cd /source && apk add git gcc musl-dev make && GOROOT=\"/usr/local/go\" make test"
+	-c "cd /source && apk add tor git gcc musl-dev make && GOROOT=\"/usr/local/go\" make test"
 
 docker-build:
 	docker run --network=host -v $(shell pwd):/source -v $(GOPATH)/pkg/mod:/go/pkg/mod golang:1.13-alpine /bin/sh \
-	-c "cd /source && apk add git gcc musl-dev make && make build"
+	-c "cd /source && apk add tor git gcc musl-dev make && make build"
 
 version:
 	@echo $(VERSION)

--- a/client.go
+++ b/client.go
@@ -5,28 +5,13 @@ import (
 	"fmt"
 	"io"
 	"log"
-	"os"
 	"strconv"
 
 	"github.com/cretz/bine/tor"
-	lumberjack "gopkg.in/natefinch/lumberjack.v2"
 )
 
 func (t *Tor) Start() {
-	var debugger io.Writer
-	if t.DebugMode {
-		if t.LogFile != "" {
-			debugger = &lumberjack.Logger{
-				Filename:   t.LogFile,
-				MaxSize:    100,
-				MaxAge:     14,
-				MaxBackups: 10,
-			}
-		}
-		debugger = os.Stdout
-	}
-
-	torInstance, err := tor.Start(nil, t.starterConfig(debugger))
+	torInstance, err := tor.Start(nil, t.starterConfig(t.debugger))
 	if err != nil {
 		log.Panicf("Unable to start Tor: %v", err)
 	}

--- a/config.go
+++ b/config.go
@@ -4,6 +4,8 @@ import (
 	"bytes"
 	"context"
 	"fmt"
+	"io"
+	"os"
 	"os/exec"
 	"strconv"
 	"time"
@@ -11,6 +13,7 @@ import (
 	"github.com/caddyserver/caddy/v2"
 	"github.com/caddyserver/caddy/v2/caddyconfig/caddyfile"
 	"github.com/cretz/bine/tor"
+	"gopkg.in/natefinch/lumberjack.v2"
 )
 
 // TorProxy config
@@ -22,13 +25,14 @@ type Config struct {
 // Tor instance config struct
 type Tor struct {
 	// Socks5 proxy port
+	Host      string
 	Port      int
 	DataDir   string
 	Torrc     string
 	DebugMode bool
 	LogFile   string
 
-	exist           bool
+	debugger        io.Writer
 	instance        *tor.Tor
 	contextCanceler context.CancelFunc
 	onion           *tor.OnionService
@@ -47,6 +51,9 @@ const (
 // ParseTor parses advanced config for Tor client
 func (t *Tor) ParseTor(d *caddyfile.Dispenser) error {
 	switch d.Val() {
+	case "host":
+		t.Host = d.RemainingArgs()[0]
+
 	case "port":
 		value, err := strconv.Atoi(d.RemainingArgs()[0])
 		if err != nil {
@@ -73,12 +80,25 @@ func (t *Tor) ParseTor(d *caddyfile.Dispenser) error {
 	default:
 		return d.ArgErr() // unhandled option for tor
 	}
+
 	return nil
 }
 
 // SetDefaults sets the default values for prometheus config
 // if the fields are empty
 func (t *Tor) SetDefaults() {
+	if t.DebugMode {
+		if t.LogFile != "" {
+			t.debugger = &lumberjack.Logger{
+				Filename:   t.LogFile,
+				MaxSize:    100,
+				MaxAge:     14,
+				MaxBackups: 10,
+			}
+		}
+		t.debugger = os.Stdout
+	}
+
 	if t.Port == 0 {
 		t.Port = DefaultOnionServicePort
 	}
@@ -115,8 +135,6 @@ func (t *Tor) IsInstalled() error {
 	if buf.String()[0:3] != "Tor" {
 		return fmt.Errorf("Tor is not installed on you machine.Please follow these instructions to install Tor: https://www.torproject.org/download/")
 	}
-
-	t.exist = true
 
 	return nil
 }

--- a/config.go
+++ b/config.go
@@ -99,6 +99,10 @@ func (t *Tor) SetDefaults() {
 		t.debugger = os.Stdout
 	}
 
+	if t.Host == "" {
+		t.Host = "127.0.0.1"
+	}
+
 	if t.Port == 0 {
 		t.Port = DefaultOnionServicePort
 	}

--- a/setup_test.go
+++ b/setup_test.go
@@ -39,6 +39,7 @@ func Test_parse(t *testing.T) {
 			Config{
 				To: map[string]string{"from.com": "http://to.onion", "from2.com": "http://to2.onion"},
 				Client: &Tor{
+					Host: "127.0.0.1",
 					Port: 4200,
 				},
 			},

--- a/setup_test.go
+++ b/setup_test.go
@@ -29,8 +29,46 @@ func Test_parse(t *testing.T) {
 				To: map[string]string{"from.com": "http://to.onion", "from2.com": "http://to2.onion"},
 			},
 		},
+		{
+			`
+			torproxy from.com to.onion 
+			torproxy from2.com to2.onion {
+				port 4200
+			}
+			`,
+			Config{
+				To: map[string]string{"from.com": "http://to.onion", "from2.com": "http://to2.onion"},
+				Client: &Tor{
+					Port: 4200,
+				},
+			},
+		},
+		{
+			`
+			torproxy from.com to.onion 
+			torproxy from2.com to2.onion {
+				host 172.168.1.1
+				port 4200
+				datadir /data/dir
+				torrc /etc/tor/torrc
+				debug_mode true
+				logfile /var/logs/stdout
+			}
+			`,
+			Config{
+				To: map[string]string{"from.com": "http://to.onion", "from2.com": "http://to2.onion"},
+				Client: &Tor{
+					Host:      "172.168.1.1",
+					Port:      4200,
+					DataDir:   "/data/dir",
+					Torrc:     "/etc/tor/torrc",
+					DebugMode: true,
+					LogFile:   "/var/logs/stdout",
+				},
+			},
+		},
 	}
-	for _, test := range tests {
+	for i, test := range tests {
 		buf := bytes.NewBuffer([]byte(test.configFile))
 		block, err := caddyfile.Parse("Caddyfile", buf)
 		if err != nil {
@@ -46,7 +84,7 @@ func Test_parse(t *testing.T) {
 		}
 
 		d := caddyfile.NewDispenser(tokens)
-		g := &TorProxy{}
+		g := &TorProxy{Config: Config{Client: &Tor{}}, testing: true}
 
 		if err := g.UnmarshalCaddyfile(d); err != nil {
 			t.Errorf("Couldn't parse the config: %s", err.Error())
@@ -55,6 +93,27 @@ func Test_parse(t *testing.T) {
 		for from, to := range g.Config.To {
 			if test.config.To[from] != to {
 				t.Errorf("Expected %+v, Got %+v", test.config.To, g.Config.To)
+			}
+		}
+
+		if test.config.Client != nil {
+			if g.Config.Client.Host != test.config.Client.Host {
+				t.Errorf("[%d]: Expected %s, but got %s", i, test.config.Client.Host, g.Config.Client.Host)
+			}
+			if g.Config.Client.Port != test.config.Client.Port {
+				t.Errorf("[%d]: Expected %d, but got %d", i, test.config.Client.Port, g.Config.Client.Port)
+			}
+			if g.Config.Client.DataDir != test.config.Client.DataDir {
+				t.Errorf("[%d]: Expected %s, but got %s", i, test.config.Client.DataDir, g.Config.Client.DataDir)
+			}
+			if g.Config.Client.Torrc != test.config.Client.Torrc {
+				t.Errorf("[%d]: Expected %s, but got %s", i, test.config.Client.Torrc, g.Config.Client.Torrc)
+			}
+			if g.Config.Client.DebugMode != test.config.Client.DebugMode {
+				t.Errorf("[%d]: Expected %t, but got %t", i, test.config.Client.DebugMode, g.Config.Client.DebugMode)
+			}
+			if g.Config.Client.LogFile != test.config.Client.LogFile {
+				t.Errorf("[%d]: Expected %s, but got %s", i, test.config.Client.LogFile, g.Config.Client.LogFile)
 			}
 		}
 	}

--- a/torproxy.go
+++ b/torproxy.go
@@ -33,7 +33,7 @@ func (c Config) Proxy(w http.ResponseWriter, r *http.Request) error {
 	r.Host = u.Host
 
 	// Create a socks5 dialer
-	dialer, err := proxy.SOCKS5("tcp", fmt.Sprintf("127.0.0.1:%d", c.Client.Port), nil, proxy.Direct)
+	dialer, err := proxy.SOCKS5("tcp", fmt.Sprintf("%s:%d", c.Client.Host, c.Client.Port), nil, proxy.Direct)
 	if err != nil {
 		return fmt.Errorf("Couldn't connect to socks proxy: %s", err.Error())
 	}


### PR DESCRIPTION
**What this PR does / why we need it**:
Fixes the config parser bug in parsing the client config and adds the host field for supporting custom Tor instances.

**Which issue this PR fixes** *(optional - uncomment and add issue)*:
fixes #22 

**Special notes for your reviewer**:

**Release note**:
<!--
Optional one line note for this specific change, that can be used in a release-note or changelog.
-->
```release-note

```
