### PR TITLE
[proxy]: Fix nil pointer error and use Go's reverse proxy

### DIFF
--- a/setup.go
+++ b/setup.go
@@ -79,8 +79,7 @@ config_handler:
 
 // CaddyModule returns the Caddy module information.
 func (TorProxy) CaddyModule() caddy.ModuleInfo {
-	t := TorProxy{Config: Config{Client: &Tor{}}}
-
+	t := &TorProxy{Config: Config{Client: &Tor{}}}
 	pool := caddy.NewUsagePool()
 	pool.LoadOrNew("torclient", TorConstructor)
 


### PR DESCRIPTION
**What this PR does / why we need it**:
Fixes nil pointer error in start and uses Go's internal reverse proxy module instead of Caddy's.

**Which issue this PR fixes** *(optional - uncomment and add issue)*:
fixes #27 

**Special notes for your reviewer**:

**Release note**:
<!--
Optional one line note for this specific change, that can be used in a release-note or changelog.
-->
```release-note

```
